### PR TITLE
Add throughput printing to RDMA poller

### DIFF
--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -109,6 +109,7 @@ private:
     std::chrono::steady_clock::time_point m_first_recv_ts;
     std::chrono::steady_clock::time_point m_last_recv_ts;
     bool m_first_ts_recorded{false};
+    std::chrono::steady_clock::time_point m_last_bw_print_ts; // last time throughput was printed
 
     // Internal helper methods for resource management and QP state transitions
     bool query_port_attributes();


### PR DESCRIPTION
## Summary
- store all received packets regardless of immediate data
- print average bandwidth every second in CQ polling thread
- track last throughput print time

## Testing
- `cmake ..` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851beaa26148324afd4eda083bde307