### PR TITLE
Truncate output file each run

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,8 @@ void print_usage(const char* prog_name) {
     std::cerr << "Usage: " << prog_name << " [options]\n\n"
               << "Manages an RDMA connection, sets up a QP to RTS, posts receive buffers,\n"
               << "and polls for completions in a separate thread. Data received via RDMA Send\n"
-              << "from the remote peer is appended to '" << DEFAULT_OUTPUT_FILENAME_H << "'.\n"
+              << "from the remote peer is written to '" << DEFAULT_OUTPUT_FILENAME_H
+              << "' (file recreated each run).\n"
               << "The QP will attempt to reset and re-initialize if it enters an error state.\n\n"
               << "Options:\n"
               << "  --device     <name>    RDMA device name (default: rocep94s0f1)\n"

--- a/src/rdma_manager.cpp
+++ b/src/rdma_manager.cpp
@@ -128,7 +128,7 @@ void RdmaManager::request_shutdown_flag() {
 
 bool RdmaManager::dump_all_received_data_to_file(const char* filename) const {
     if (!filename) return false;
-    FILE* f = fopen(filename, "ab");
+    FILE* f = fopen(filename, "wb");
     if (!f) {
         perror("dump_all_received_data_to_file: fopen failed");
         return false;
@@ -574,7 +574,7 @@ void RdmaManager::cq_poll_loop_func() {
 
     FILE *output_file = nullptr;
     if (m_write_immediately) {
-        output_file = fopen(DEFAULT_OUTPUT_FILENAME_H, "ab");
+        output_file = fopen(DEFAULT_OUTPUT_FILENAME_H, "wb");
         if (!output_file) {
             perror("[CQ Thread] Failed to open output file");
             std::cerr << "[CQ Thread] Warning: Received data will not be saved to file." << std::endl;


### PR DESCRIPTION
## Summary
- overwrite the binary output file instead of appending
- ensure CQ thread truncates the output file when created
- update usage to describe file recreation each run

## Testing
- `cmake .. && make -j$(nproc)` *(fails: Package 'libibverbs', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_685312239cf88324833ab09ac2f8bace