### PR TITLE
Save runtime RDMA parameters to JSON

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,6 +235,11 @@ int main(int argc, char* argv[]) {
             return EXIT_FAILURE;
         }
 
+        // Save connection parameters including current message size
+        if (!rdma_manager.write_params_to_json(DEFAULT_PARAMS_FILENAME_H, param_recv_slice_size)) {
+            std::cerr << "Main: Warning - failed to write connection parameters file." << std::endl;
+        }
+
         rdma_manager.start_cq_polling_thread();
 
         std::cout << "Main thread: CQ polling thread started." << std::endl;

--- a/src/rdma_manager.cpp
+++ b/src/rdma_manager.cpp
@@ -704,3 +704,30 @@ void RdmaManager::print_performance_stats() const {
     std::cout << "Data received: " << mb << " MB in " << seconds
               << " s (" << mbps << " MB/s)." << std::endl;
 }
+
+bool RdmaManager::write_params_to_json(const char* filename, size_t msg_size) const {
+    if (!filename || !m_main_mr) {
+        return false;
+    }
+    FILE* f = fopen(filename, "w");
+    if (!f) {
+        perror("write_params_to_json: fopen failed");
+        return false;
+    }
+    fprintf(f,
+            "{\n"
+            "  \"local_qpn\": %u,\n"
+            "  \"mr_rkey\": %u,\n"
+            "  \"mr_addr\": \"0x%lx\",\n"
+            "  \"buffer_size\": %zu,\n"
+            "  \"msg_size\": %zu\n"
+            "}\n",
+            m_local_qpn,
+            m_main_mr->rkey,
+            (unsigned long)m_main_mr->addr,
+            m_buffer_size_actual,
+            msg_size);
+    fclose(f);
+    std::cout << "Connection parameters written to '" << filename << "'." << std::endl;
+    return true;
+}

--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -28,6 +28,7 @@ constexpr int DEFAULT_NUM_RECV_WRS_H = 32;          // Match the sender's queue
 constexpr size_t DEFAULT_BUFFER_SIZE_H =
     DEFAULT_RECV_BUFFER_SLICE_SIZE_H * DEFAULT_NUM_RECV_WRS_H; // 3.2GB
 constexpr const char* DEFAULT_OUTPUT_FILENAME_H = "fpga_received_data_cpp.bin";
+constexpr const char* DEFAULT_PARAMS_FILENAME_H = "rdma_params.json";
 constexpr int DEFAULT_CQ_SIZE_H = DEFAULT_NUM_RECV_WRS_H * 2; // Recommended CQ size relative to WRs
 
 // Structure to manage individual receive buffer slots within a larger registered MR
@@ -88,6 +89,9 @@ public:
 
     // Prints throughput statistics based on recorded timestamps and bytes
     void print_performance_stats() const;
+
+    // Write connection parameters (rkey, qpn, addresses, etc.) to a JSON file
+    bool write_params_to_json(const char* filename, size_t msg_size) const;
 
     // Convert an ibv_mtu enumeration to the corresponding byte value.  This
     // helper is public so callers outside the class can easily print or use the


### PR DESCRIPTION
## Summary
- add default filename for RDMA params JSON
- add API to write connection parameters to JSON including msg_size
- save parameters from `main` after initialization

## Testing
- `cmake ..` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854160c696c8324bf19ec6176c712e0