### PR TITLE
Improve throughput performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(RdmaCppApp CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -g") # Enable warnings and debug symbols
+# Enable warnings, optimisation and disable extra runtime cost in release builds
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O3 -DNDEBUG")
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(IBVERBS REQUIRED libibverbs)

--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -141,9 +141,6 @@ private:
     std::chrono::steady_clock::time_point m_last_recv_ts;
     bool m_first_ts_recorded{false};
     std::chrono::steady_clock::time_point m_last_bw_print_ts; // last time throughput was printed
-    // Timestamp of the previous receive completion for per-transfer throughput
-    std::chrono::steady_clock::time_point m_prev_recv_ts;
-    bool m_prev_ts_valid{false};
 
     bool m_write_immediately{false};
     RecvOpType m_recv_op_type{RecvOpType::WRITE};


### PR DESCRIPTION
## Summary
- stop measuring throughput on every work completion
- remove unused timestamp fields
- build with release optimization flags

## Testing
- `cmake .. && make -j$(nproc)` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557c9f6f7c8324ad44d58a46609268