### PR TITLE
Stream RDMA data directly to disk

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,9 @@ void print_usage(const char* prog_name) {
               << DEFAULT_RECV_BUFFER_SLICE_SIZE_H << " bytes)\n"
               << "  --mtu         <256|512|1024|2048|4096> Path MTU (default: 4096)\n"
               << "  --recv_op    <send|write> Operation used by peer to send data (default: write)\n"
-              << "  --write_file           Write data to file during receive (default: off)\n"
+              << "  --write_file           Stream received data directly to file (default: off).\n"
+              << "                         Without this flag only the last " << RdmaManager::MAX_STORED_MSGS
+              << " messages are kept in memory.\n"
               << "  -h, --help             Show this help message and exit\n"
               << "\nExample: " << prog_name << " --sgid_idx 4 --remote_qpn 0x100\n"
               << std::endl;
@@ -192,7 +194,7 @@ int main(int argc, char* argv[]) {
               << ", Message Size: " << param_recv_slice_size << " bytes" << std::endl;
     std::cout << "Path MTU: " << RdmaManager::mtu_enum_to_value(param_mtu) << " bytes" << std::endl;
     std::cout << "Receive operation: " << (param_recv_op == RecvOpType::WRITE ? "write" : "send") << std::endl;
-    std::cout << "Write data during receive: " << (param_write_file ? "yes" : "no") << std::endl;
+    std::cout << "Stream data to file: " << (param_write_file ? "yes" : "no") << std::endl;
     std::cout << "-----------------------------" << std::endl;
     
     if (param_ib_port <= 0) { std::cerr << "Error: Port number must be positive." << std::endl; return EXIT_FAILURE; }

--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -4,6 +4,7 @@
 #include <infiniband/verbs.h>
 #include <string>
 #include <vector>
+#include <deque>
 #include <atomic>
 #include <thread>
 #include <stdexcept> // For std::runtime_error
@@ -93,10 +94,15 @@ public:
     // Write connection parameters (rkey, qpn, addresses, etc.) to a JSON file
     bool write_params_to_json(const char* filename, size_t msg_size) const;
 
+
     // Convert an ibv_mtu enumeration to the corresponding byte value.  This
     // helper is public so callers outside the class can easily print or use the
     // configured MTU size.
     static int mtu_enum_to_value(enum ibv_mtu mtu);
+
+    // Only the most recent messages are kept in memory when write_immediately
+    // is disabled. Exposed here for help text and diagnostics.
+    static constexpr size_t MAX_STORED_MSGS = 100;
 
 
 private:
@@ -131,10 +137,11 @@ private:
     std::atomic<bool> m_qp_in_error_state;  // Flag indicating QP is in error
     std::thread m_cq_thread;                // Thread object for CQ polling
 
-    // Statistics and storage for received data (from RECV_RDMA_WITH_IMM)
+    // Statistics and limited storage for received data (from RECV_RDMA_WITH_IMM)
     size_t m_total_recv_msgs{0};
     size_t m_total_recv_bytes{0};
-    std::vector<std::vector<char>> m_all_received_data; // Sequential storage
+    // Only the most recent messages are kept in memory when write_immediately is false
+    std::deque<std::vector<char>> m_recent_received_data;
 
     // Timing information for throughput calculation
     std::chrono::steady_clock::time_point m_first_recv_ts;
@@ -148,7 +155,7 @@ private:
     bool m_write_immediately{false};
     RecvOpType m_recv_op_type{RecvOpType::WRITE};
 
-    bool dump_all_received_data_to_file(const char* filename) const;
+    bool dump_all_received_data_to_file(const char* filename) const; // Dumps only messages still held in memory
 
     // Internal helper methods for resource management and QP state transitions
     bool query_port_attributes();


### PR DESCRIPTION
## Summary
- keep a limited number of received messages in memory
- stream data directly to file when `--write_file` is enabled
- expose `MAX_STORED_MSGS` so help text can reference it

## Testing
- `cmake ..` *(fails: libibverbs missing)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68558cbfdd10832491d50d493a5fedf1