### PR TITLE
Add CQ event-driven option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,8 @@ void print_usage(const char* prog_name) {
               << DEFAULT_RECV_BUFFER_SLICE_SIZE_H << " bytes)\n"
               << "  --mtu         <256|512|1024|2048|4096> Path MTU (default: 4096)\n"
               << "  --recv_op    <send|write> Operation used by peer to send data (default: write)\n"
+              << "  --poll_us    <us>      CQ idle poll interval in microseconds (default: " << DEFAULT_CQ_POLL_US_H << ")\n"
+              << "  --cq_event            Use CQ event notifications instead of polling\n"
               << "  --write_file           Stream received data directly to file (default: off).\n"
               << "                         Without this flag only the last " << RdmaManager::MAX_STORED_MSGS
               << " messages are kept in memory.\n"
@@ -83,6 +85,8 @@ int main(int argc, char* argv[]) {
     enum ibv_mtu param_mtu = IBV_MTU_4096;
     bool param_write_file = false;
     RecvOpType param_recv_op = RecvOpType::WRITE;
+    int param_cq_poll_us = DEFAULT_CQ_POLL_US_H;
+    bool param_cq_event = false;
 
     // Command line argument parsing
     int opt_char;
@@ -100,6 +104,8 @@ int main(int argc, char* argv[]) {
         {"msg_size",   required_argument, 0, 'm'},
         {"mtu",        required_argument, 0, 'u'},
         {"recv_op",   required_argument, 0, 'o'},
+        {"poll_us",   required_argument, 0, 'l'},
+        {"cq_event", no_argument,       0, 'e'},
         {"write_file", no_argument,       0, 'f'},
         {"help",       no_argument,       0, 'h'},
         {0, 0, 0, 0}
@@ -167,6 +173,13 @@ int main(int argc, char* argv[]) {
                     return EXIT_FAILURE;
                 }
                 break;
+            case 'l':
+                try { param_cq_poll_us = std::stoi(optarg); }
+                catch (const std::exception& e) { std::cerr << "Invalid poll_us '" << optarg << "': " << e.what() << std::endl; return EXIT_FAILURE; }
+                break;
+            case 'e':
+                param_cq_event = true;
+                break;
             case 'f':
                 param_write_file = true;
                 break;
@@ -194,6 +207,8 @@ int main(int argc, char* argv[]) {
               << ", Message Size: " << param_recv_slice_size << " bytes" << std::endl;
     std::cout << "Path MTU: " << RdmaManager::mtu_enum_to_value(param_mtu) << " bytes" << std::endl;
     std::cout << "Receive operation: " << (param_recv_op == RecvOpType::WRITE ? "write" : "send") << std::endl;
+    std::cout << "CQ poll interval: " << param_cq_poll_us << " us" << std::endl;
+    std::cout << "CQ event mode: " << (param_cq_event ? "on" : "off") << std::endl;
     std::cout << "Stream data to file: " << (param_write_file ? "yes" : "no") << std::endl;
     std::cout << "-----------------------------" << std::endl;
     
@@ -205,7 +220,8 @@ int main(int argc, char* argv[]) {
                                  param_pc_initial_sq_psn, param_buffer_size,
                                  param_num_recv_wrs, param_recv_slice_size,
                                  param_mtu, param_write_file,
-                                 param_recv_op);
+                                 param_recv_op, param_cq_poll_us,
+                                 param_cq_event);
         
         g_app_rdma_manager_instance_ptr.store(&rdma_manager);
 

--- a/src/rdma_manager.cpp
+++ b/src/rdma_manager.cpp
@@ -43,7 +43,9 @@ RdmaManager::RdmaManager(const std::string& dev_name, int port, uint8_t sgid_idx
                          size_t buffer_sz, int num_recv_wrs, size_t recv_slice_sz,
                          enum ibv_mtu path_mtu,
                          bool write_immediately,
-                         RecvOpType recv_op)
+                         RecvOpType recv_op,
+                         int cq_poll_us,
+                         bool use_cq_event)
     : m_context(nullptr), m_pd(nullptr), m_cq(nullptr), m_qp(nullptr),
       m_main_buffer_ptr(nullptr), m_main_mr(nullptr),
       m_device_name(dev_name), m_ib_port(port), m_local_sgid_index(sgid_idx),
@@ -55,6 +57,9 @@ RdmaManager::RdmaManager(const std::string& dev_name, int port, uint8_t sgid_idx
       m_num_recv_wrs_actual(num_recv_wrs),
       m_recv_slice_size_actual(recv_slice_sz),
       m_cq_size_actual(num_recv_wrs * 2),
+      m_cq_poll_us_actual(cq_poll_us),
+      m_use_cq_event(use_cq_event),
+      m_comp_channel(nullptr),
       m_shutdown_requested(false), m_qp_in_error_state(false),
       m_total_recv_msgs(0), m_total_recv_bytes(0),
       m_write_immediately(write_immediately),
@@ -76,6 +81,8 @@ RdmaManager::RdmaManager(const std::string& dev_name, int port, uint8_t sgid_idx
     std::cout << "  Receiving operation type: "
               << (m_recv_op_type == RecvOpType::WRITE ? "write" : "send")
               << std::endl;
+    std::cout << "  CQ idle poll interval: " << m_cq_poll_us_actual << " us" << std::endl;
+    std::cout << "  CQ event driven: " << (m_use_cq_event ? "yes" : "no") << std::endl;
     // Signal handling will be set up in main.cpp using a global pointer to this instance
 }
 
@@ -108,6 +115,10 @@ RdmaManager::~RdmaManager() {
         perror("~RdmaManager: ibv_destroy_cq failed");
     }
     m_cq = nullptr;
+    if (m_comp_channel && ibv_destroy_comp_channel(m_comp_channel)) {
+        perror("~RdmaManager: ibv_destroy_comp_channel failed");
+    }
+    m_comp_channel = nullptr;
     if (m_main_mr && ibv_dereg_mr(m_main_mr)) {
         perror("~RdmaManager: ibv_dereg_mr failed");
     }
@@ -258,10 +269,25 @@ bool RdmaManager::register_memory_region() {
 
 // Create Completion Queue
 bool RdmaManager::create_completion_queue() {
-    m_cq = ibv_create_cq(m_context, m_cq_size_actual, NULL, NULL, 0);
+    if (m_use_cq_event) {
+        m_comp_channel = ibv_create_comp_channel(m_context);
+        if (!m_comp_channel) {
+            perror("ibv_create_comp_channel failed");
+            return false;
+        }
+        m_cq = ibv_create_cq(m_context, m_cq_size_actual, NULL, m_comp_channel, 0);
+    } else {
+        m_cq = ibv_create_cq(m_context, m_cq_size_actual, NULL, NULL, 0);
+    }
     if (!m_cq) {
         perror("ibv_create_cq failed");
         return false;
+    }
+    if (m_use_cq_event) {
+        if (ibv_req_notify_cq(m_cq, 0)) {
+            perror("ibv_req_notify_cq failed");
+            return false;
+        }
     }
     std::cout << "CQ created with " << m_cq_size_actual << " entries." << std::endl;
     return true;
@@ -584,8 +610,10 @@ void RdmaManager::process_work_completion(struct ibv_wc* wc, FILE* outfile) {
 
 // The actual CQ polling loop function, run in a separate thread
 void RdmaManager::cq_poll_loop_func() {
-    std::cout << "[CQ Thread] Started. Local QP 0x" << std::hex << m_local_qpn 
-              << " is RTS. Waiting for events..." << std::dec << std::endl;
+    std::cout << "[CQ Thread] Started. Local QP 0x" << std::hex << m_local_qpn
+              << " is RTS. "
+              << (m_use_cq_event ? "Waiting for CQ events..." : "Polling CQ...")
+              << std::dec << std::endl;
 
     FILE *output_file = nullptr;
     if (m_write_immediately) {
@@ -619,7 +647,7 @@ void RdmaManager::cq_poll_loop_func() {
         int num_wcs = ibv_poll_cq(m_cq, m_cq_size_actual, wc_array.data());
         if (num_wcs < 0) {
             perror("[CQ Thread] ibv_poll_cq failed");
-            request_shutdown_flag(); 
+            request_shutdown_flag();
             break;
         }
 
@@ -631,8 +659,21 @@ void RdmaManager::cq_poll_loop_func() {
         }
 
         if (num_wcs == 0 && !m_shutdown_requested.load() && !m_qp_in_error_state.load()) {
-            // No completions, not shutting down, not in error -> can sleep briefly
-            usleep(1000); // Sleep for 1ms to reduce CPU busy-wait in idle poll
+            if (m_use_cq_event) {
+                struct ibv_cq *ev_cq;
+                void *ev_ctx;
+                int ret = ibv_get_cq_event(m_comp_channel, &ev_cq, &ev_ctx);
+                if (ret == 0) {
+                    ibv_ack_cq_events(ev_cq, 1);
+                    ibv_req_notify_cq(m_cq, 0);
+                } else {
+                    perror("[CQ Thread] ibv_get_cq_event failed");
+                    request_shutdown_flag();
+                    break;
+                }
+            } else if (m_cq_poll_us_actual > 0) {
+                usleep(m_cq_poll_us_actual);
+            }
         }
 
         auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
## Summary
- add `use_cq_event` parameter to `RdmaManager`
- create completion channel and re-arm CQ notifications
- handle CQ events in polling loop
- expose new `--cq_event` option in `main.cpp`

## Testing
- `cmake ..` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559435e8b08324b6a53351b76c0f79