### PR TITLE
Improve CQ thread shutdown handling

### DIFF
--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -132,6 +132,8 @@ private:
     size_t m_recv_slice_size_actual;
     int m_cq_size_actual;
 
+    struct ibv_comp_channel* m_comp_channel; // Completion channel when events used
+
     // State and Threading
     std::atomic<bool> m_shutdown_requested; // Flag to signal shutdown to threads/loops
     std::atomic<bool> m_qp_in_error_state;  // Flag indicating QP is in error


### PR DESCRIPTION
## Summary
- add `<poll.h>` include for polling the completion channel
- wait with `poll()` to allow shutdown while blocked on `ibv_get_cq_event`

## Testing
- `cmake ..` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559435e8b08324b6a53351b76c0f79