### PR TITLE
Add optional verbose logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,7 @@ void print_usage(const char* prog_name) {
               << "  --write_file           Stream received data directly to file (default: off).\n"
               << "                         Without this flag only the last " << RdmaManager::MAX_STORED_MSGS
               << " messages are kept in memory.\n"
+              << "  --verbose             Enable detailed per-WC logging.\n"
               << "  -h, --help             Show this help message and exit\n"
               << "\nExample: " << prog_name << " --sgid_idx 4 --remote_qpn 0x100\n"
               << std::endl;
@@ -83,6 +84,7 @@ int main(int argc, char* argv[]) {
     enum ibv_mtu param_mtu = IBV_MTU_4096;
     bool param_write_file = false;
     RecvOpType param_recv_op = RecvOpType::WRITE;
+    bool param_verbose = false;
 
     // Command line argument parsing
     int opt_char;
@@ -101,11 +103,12 @@ int main(int argc, char* argv[]) {
         {"mtu",        required_argument, 0, 'u'},
         {"recv_op",   required_argument, 0, 'o'},
         {"write_file", no_argument,       0, 'f'},
+        {"verbose",    no_argument,       0, 'v'},
         {"help",       no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
 
-    while ((opt_char = getopt_long(argc, argv, "h", long_options, &option_index)) != -1) {
+    while ((opt_char = getopt_long(argc, argv, "hv", long_options, &option_index)) != -1) {
         switch (opt_char) {
             case 'd': param_device_name = optarg; break;
             case 'p': 
@@ -170,6 +173,9 @@ int main(int argc, char* argv[]) {
             case 'f':
                 param_write_file = true;
                 break;
+            case 'v':
+                param_verbose = true;
+                break;
             case 'h': print_usage(argv[0]); return EXIT_SUCCESS;
             case '?': // getopt_long already printed an error message
             default:  print_usage(argv[0]); return EXIT_FAILURE;
@@ -195,6 +201,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Path MTU: " << RdmaManager::mtu_enum_to_value(param_mtu) << " bytes" << std::endl;
     std::cout << "Receive operation: " << (param_recv_op == RecvOpType::WRITE ? "write" : "send") << std::endl;
     std::cout << "Stream data to file: " << (param_write_file ? "yes" : "no") << std::endl;
+    std::cout << "Verbose logging: " << (param_verbose ? "yes" : "no") << std::endl;
     std::cout << "-----------------------------" << std::endl;
     
     if (param_ib_port <= 0) { std::cerr << "Error: Port number must be positive." << std::endl; return EXIT_FAILURE; }
@@ -205,7 +212,7 @@ int main(int argc, char* argv[]) {
                                  param_pc_initial_sq_psn, param_buffer_size,
                                  param_num_recv_wrs, param_recv_slice_size,
                                  param_mtu, param_write_file,
-                                 param_recv_op);
+                                 param_recv_op, param_verbose);
         
         g_app_rdma_manager_instance_ptr.store(&rdma_manager);
 

--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -68,7 +68,8 @@ public:
                 size_t recv_slice_sz = DEFAULT_RECV_BUFFER_SLICE_SIZE_H,
                 enum ibv_mtu path_mtu = IBV_MTU_4096,
                 bool write_immediately = false,
-                RecvOpType recv_op = RecvOpType::WRITE);
+                RecvOpType recv_op = RecvOpType::WRITE,
+                bool verbose_logging = false);
     
     // Destructor (handles resource cleanup via RAII)
     ~RdmaManager();
@@ -132,6 +133,8 @@ private:
     size_t m_recv_slice_size_actual;
     int m_cq_size_actual;
 
+    struct ibv_comp_channel* m_comp_channel; // Completion channel when events used
+
     // State and Threading
     std::atomic<bool> m_shutdown_requested; // Flag to signal shutdown to threads/loops
     std::atomic<bool> m_qp_in_error_state;  // Flag indicating QP is in error
@@ -157,6 +160,7 @@ private:
 
     bool m_write_immediately{false};
     RecvOpType m_recv_op_type{RecvOpType::WRITE};
+    bool m_verbose{false};
 
     bool dump_all_received_data_to_file(const char* filename) const; // Dumps only messages still held in memory
 


### PR DESCRIPTION
## Summary
- allow per-work-completion logging to be toggled with a `--verbose` flag
- hide success messages unless verbose logging is enabled

## Testing
- `cmake -S . -B build` *(fails: libibverbs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559435e8b08324b6a53351b76c0f79