### PR TITLE
Fix throughput statistics intervals

### DIFF
--- a/src/rdma_manager.cpp
+++ b/src/rdma_manager.cpp
@@ -104,6 +104,7 @@ RdmaManager::RdmaManager(const std::string& dev_name, int port, uint8_t sgid_idx
       m_comp_channel(nullptr),
       m_shutdown_requested(false), m_qp_in_error_state(false),
       m_total_recv_msgs(0), m_total_recv_bytes(0),
+      m_stats_interval_start(), m_prev_total_bytes(0), m_new_interval(true),
       m_write_immediately(write_immediately),
       m_recv_op_type(recv_op),
       m_debug_enabled(debug_enabled),
@@ -599,11 +600,16 @@ void RdmaManager::process_work_completion(struct ibv_wc* wc, FILE* outfile) {
 
     if (wc->status == IBV_WC_SUCCESS) {
         if (wc->opcode == IBV_WC_RECV || wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+            auto now = std::chrono::steady_clock::now();
             if (!m_first_ts_recorded) {
-                m_first_recv_ts = std::chrono::steady_clock::now();
+                m_first_recv_ts = now;
                 m_first_ts_recorded = true;
             }
-            m_last_recv_ts = std::chrono::steady_clock::now();
+            if (m_new_interval) {
+                m_stats_interval_start = now;
+                m_new_interval = false;
+            }
+            m_last_recv_ts = now;
             m_stats_printed = false; // new data arrived
             if (wc->wr_id < m_recv_slots.size()) {
                 RecvBufferSlot& slot = m_recv_slots[wc->wr_id];
@@ -776,23 +782,29 @@ void RdmaManager::stop_cq_polling_thread() {
     }
 }
 
-// Print basic throughput statistics based on recorded timestamps
-void RdmaManager::print_performance_stats() const {
-    if (!m_first_ts_recorded || m_total_recv_bytes == 0) {
+// Print throughput statistics since the last time this function was called
+void RdmaManager::print_performance_stats() {
+    if (!m_first_ts_recorded || m_total_recv_bytes == m_prev_total_bytes) {
         std::cout << "No receive timing information recorded." << std::endl;
         return;
     }
 
-    auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(m_last_recv_ts - m_first_recv_ts);
+    auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(m_last_recv_ts - m_stats_interval_start);
     double seconds = duration.count();
     if (seconds <= 0.0) {
         std::cout << "Duration too small to compute throughput." << std::endl;
         return;
     }
-    double mb = static_cast<double>(m_total_recv_bytes) / (1024.0 * 1024.0);
+    size_t bytes = m_total_recv_bytes - m_prev_total_bytes;
+    double mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
     double mbps = mb / seconds;
     std::cout << "Data received: " << mb << " MB in " << seconds
               << " s (" << mbps << " MB/s)." << std::endl;
+
+    // Reset counters for the next interval; the next receive will set the start time
+    m_stats_interval_start = m_last_recv_ts;
+    m_prev_total_bytes = m_total_recv_bytes;
+    m_new_interval = true;
 }
 
 bool RdmaManager::write_params_to_json(const char* filename, size_t msg_size) const {

--- a/src/rdma_manager.h
+++ b/src/rdma_manager.h
@@ -90,7 +90,7 @@ public:
     bool post_all_initial_recv_wrs();        // Posts receive WRs for all available slots
 
     // Prints throughput statistics based on recorded timestamps and bytes
-    void print_performance_stats() const;
+    void print_performance_stats();
 
     // Write connection parameters (rkey, qpn, addresses, etc.) to a JSON file
     bool write_params_to_json(const char* filename, size_t msg_size) const;
@@ -153,6 +153,11 @@ private:
     std::chrono::steady_clock::time_point m_first_recv_ts;
     std::chrono::steady_clock::time_point m_last_recv_ts;
     bool m_first_ts_recorded{false};
+
+    // Track interval start for throughput statistics
+    std::chrono::steady_clock::time_point m_stats_interval_start;
+    size_t m_prev_total_bytes{0};
+    bool m_new_interval{true};
 
     // Idle timeout before computing final throughput in the polling thread
     std::chrono::steady_clock::duration m_idle_timeout{std::chrono::seconds(5)};


### PR DESCRIPTION
## Summary
- add flag to start new stats interval on first work completion after a print
- reset `m_new_interval` in `print_performance_stats`
- initialize the flag in the constructor

## Testing
- `cmake .. && make -j4` *(fails: libibverbs missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e754d55748324807eaa3eb88fdf29